### PR TITLE
Small fix, missing depends on dependencies see past issue.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Only requirement is that it accepts one argument (request) and that it returns e
 
 
 ```python3
-@app.get("/hello/{name}", dependencies=[Etag(get_hello_etag)])
+@app.get("/hello/{name}", dependencies=[Depends(Etag(get_hello_etag))])
 def hello(name: str):
 	...
 ```


### PR DESCRIPTION
Can you also update pip ?
https://pypi.org/project/fastapi-etag/
The description is not updated.
Thanks! great work.
